### PR TITLE
Fix `nextcloud` js check error

### DIFF
--- a/docker-compose-t2.yml
+++ b/docker-compose-t2.yml
@@ -1604,7 +1604,6 @@ services:
     image: nextcloud:28
     # ports:
     #   - 443:443
-    hostname: drive.$DOMAINNAME0
     volumes:
       - $APPDIR/nextcloud:/var/www/html
       - $APPDIR/nextcloud/custom_apps:/var/www/html/custom_apps


### PR DESCRIPTION
Fix #40 by omitting `hostname` from docker compose file.

[Nextcloud help reference](https://help.nextcloud.com/t/could-not-check-for-javascript-support-please-check-manually-if-your-webserver-serves-mjs-files-using-the-javascript-mime-type/182321/13)