### PR TITLE
Do not back up the `mariadb` `data` dir

### DIFF
--- a/backup-scripts/borg-patternfile.example.lst
+++ b/backup-scripts/borg-patternfile.example.lst
@@ -239,7 +239,9 @@ R /home/<USER>/docker
 ## MariaDB #############################
 ########################################
 + /home/<USER>/docker/appdata/mariadb/config
-+ /home/<USER>/docker/appdata/mariadb/data
+
+# Backed up via `mariadb-dump`
+! /home/<USER>/docker/appdata/mariadb/data
 
 - /home/<USER>/docker/appdata/mariadb/**
 


### PR DESCRIPTION
Redundant backup given use of [`backup-mariadb.sh`](https://github.com/trjohnson19/docker-stack/blob/d422617dbcf093f95bf99ea4006a7563f12ac460/backup-scripts/backup-mariadb.sh)