### PR TITLE
Fix `wireguard` loadbalanced port

### DIFF
--- a/docker-compose-t2.yml
+++ b/docker-compose-t2.yml
@@ -2016,7 +2016,7 @@ services:
       # - "traefik.udp.routers.wireguard-udp.middlewares=chain-no-auth@file"
       ## UDP Services
       - "traefik.udp.routers.wireguard-udp.service=wireguard-udp-svc"
-      - "traefik.udp.services.wireguard-udp-svc.loadbalancer.server.port=$WIREGUARD_PORT"
+      - "traefik.udp.services.wireguard-udp-svc.loadbalancer.server.port=51820"
 
   ## Gluetun - VPN client in a thin Docker container
   gluetun:


### PR DESCRIPTION
Use port `51820` for `wireguard` port. Fixes regression introduced in e713ffd9f0ea27b777215e64f9502351ff95b3d3.