### PR TITLE
Disable `dozzle` analytics

### DIFF
--- a/docker-compose-t2.yml
+++ b/docker-compose-t2.yml
@@ -1225,6 +1225,7 @@ services:
       ## limits logs displayed to containers with this label
       # DOZZLE_FILTER: "label=log_me"
       DOZZLE_LEVEL: info
+      DOZZLE_NO_ANALYTICS: true
     # volumes:
     #   ## Use Docker Socket Proxy instead for improved security
     #   - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Disable `dozzle` analytics. Was calling analytics server thousands of times in a short period, flooding my Pi-Hole. Can revisit enabling analytics again in the future if it quiets down.

![image](https://github.com/user-attachments/assets/c792b934-69c0-4962-b718-f87698b1ff2d)
